### PR TITLE
Fix logging error in Notion project fetch

### DIFF
--- a/cvbuilder/src/notion/projects.py
+++ b/cvbuilder/src/notion/projects.py
@@ -18,7 +18,15 @@ def fetch_projects(project_id):
     response = requests.post(url, headers=NOTION_BASE_HEADERS)
 
     if response.status_code != 200:
-        logger.error("Error fetching data:", response.json())
+        # The logging call previously passed the response JSON as a separate argument
+        # without a formatting placeholder which caused a TypeError during
+        # string formatting. We explicitly format the error message so the
+        # response body is logged correctly.
+        try:
+            error_detail = response.json()
+        except ValueError:
+            error_detail = response.text
+        logger.error("Error fetching data: %s", error_detail)
         return None
 
     return response.json()


### PR DESCRIPTION
## Summary
- avoid TypeError when Notion project fetch fails by formatting error logging correctly
- include response body in log message

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6898a85da5d8832fa7d556f48657a740