### PR TITLE
docs: clarify certificate serialization

### DIFF
--- a/cvbuilder/src/notion/certificates.py
+++ b/cvbuilder/src/notion/certificates.py
@@ -65,7 +65,7 @@ def save_certificates_to_file(data):
     """Save list of Certificate models to JSON"""
     os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
     with open(DATA_PATH, 'w', encoding='utf-8') as f:
-        # Serialize using .dict() for Pydantic models
+        # Serialize using .model_dump(mode="json") for Pydantic models
         json.dump([c.model_dump(mode="json") for c in data], f, indent=2, ensure_ascii=False)
     logger.info(f"Saved {len(data)} certificates to {DATA_PATH}")
 


### PR DESCRIPTION
## Summary
- update certificate serialization comment to reference `.model_dump(mode="json")`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ae13e510832fb210afdff326b7b7