### PR TITLE
Fix typos in API utilities

### DIFF
--- a/cvbuilder/src/utils/api.py
+++ b/cvbuilder/src/utils/api.py
@@ -7,22 +7,22 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Notion API Configuration
-NOTINOTION_API_KEY = os.getenv("NOTION_API_KEY")
+NOTION_API_KEY = os.getenv("NOTION_API_KEY")
 
 NOTION_BASE_HEADERS = {
-    "Authorization": f"Bearer {NOTINOTION_API_KEY}",
+    "Authorization": f"Bearer {NOTION_API_KEY}",
     "Content-Type": "application/json",
     "Notion-Version": "2022-06-28"
 }
 
-def askchatgpt(model: ChatModel | str, qusetion: str):
+def askchatgpt(model: ChatModel | str, question: str):
     client = OpenAI()
     completion = client.chat.completions.create(
         model=model,
         messages=[
             {
                 "role": "user",
-                "content": qusetion
+                "content": question
             }
         ]
     )


### PR DESCRIPTION
## Summary
- fix Notion API key constant name
- correct `question` parameter in `askchatgpt`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898adf998a0832fab0c3c63d709cb09