### PR TITLE
Add tests for LaTeX escaping

### DIFF
--- a/cvbuilder/src/latex.py
+++ b/cvbuilder/src/latex.py
@@ -1,6 +1,7 @@
 from src.utils.logger import get_logger
 
 import os
+import re
 import subprocess
 from jinja2 import Environment, FileSystemLoader
 
@@ -38,9 +39,8 @@ def escape_latex(s):
         '~': r'\textasciitilde{}', '^': r'\textasciicircum{}',
         '\\': r'\textbackslash{}',
     }
-    for old, new in replace.items():
-        s = s.replace(old, new)
-    return s
+    pattern = re.compile('|'.join(re.escape(k) for k in replace))
+    return pattern.sub(lambda m: replace[m.group()], s)
 
 def render_template(template_name, context):
     try:

--- a/cvbuilder/tests/test_latex_escape.py
+++ b/cvbuilder/tests/test_latex_escape.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.latex import escape_latex
+
+@pytest.mark.parametrize(
+    "raw, escaped",
+    [
+        ("&", r"\&"),
+        ("%", r"\%"),
+        ("$", r"\$"),
+        ("_", r"\_"),
+        ("\\", r"\textbackslash{}"),
+    ],
+)
+def test_escape_special_chars(raw, escaped):
+    assert escape_latex(raw) == escaped
+
+@pytest.mark.parametrize("value", [123, None, ["list"]])
+def test_non_string_returns_input_unchanged(value):
+    assert escape_latex(value) is value


### PR DESCRIPTION
## Summary
- add dedicated tests for escape_latex covering special characters and non-string inputs
- fix escape_latex to escape characters correctly via regex
- make src a package to allow imports in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ae437024832fa178f5b534f135d2