### PR TITLE
Add pydantic and pytest to requirements

### DIFF
--- a/cvbuilder/requirements.txt
+++ b/cvbuilder/requirements.txt
@@ -2,3 +2,5 @@ python-dotenv
 requests
 openai
 Jinja2
+pytest
+pydantic>=1.10


### PR DESCRIPTION
## Summary
- Add pydantic>=1.10 and pytest to project requirements
- Ensure dependencies installed by Docker build and setup scripts

## Testing
- `pip install -r cvbuilder/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899083494ec832f88cbae7de40aff39