### PR TITLE
Remove project dates and pass durations to LaTeX

### DIFF
--- a/cvbuilder/src/schemas/notion.py
+++ b/cvbuilder/src/schemas/notion.py
@@ -20,8 +20,7 @@ class Project(BaseModel):
     tech_stack: List[str]
     description: Optional[str] = None
     notes: Optional[str] = None
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
+    duration: Optional[str] = None
     role: Optional[str] = None
     tags: List[str]
 

--- a/cvbuilder/tests/test_projects_duration.py
+++ b/cvbuilder/tests/test_projects_duration.py
@@ -1,0 +1,26 @@
+from src.notion.projects import extract_project_data
+
+
+def test_extract_project_duration():
+    notion_data = {
+        "results": [
+            {
+                "properties": {
+                    "Project name": {"title": [{"text": {"content": "Test Project"}}]},
+                    "Status": {"select": {"name": "Done"}},
+                    "Category": {"select": {"name": "AI"}},
+                    "Tech Stack": {"multi_select": [{"name": "Python"}]},
+                    "Description": {"rich_text": [{"text": {"content": "Desc"}}]},
+                    "Detailed Notes": {"rich_text": [{"text": {"content": "Notes"}}]},
+                    "Start Date": {"date": {"start": "2023-01-01"}},
+                    "End Date": {"date": {"start": "2023-04-01"}},
+                    "Role": {"select": {"name": "Dev"}},
+                    "Tags": {"multi_select": [{"name": "ML"}]},
+                }
+            }
+        ]
+    }
+    projects = extract_project_data(notion_data)
+    assert projects[0].duration == "3 mo"
+    dump = projects[0].model_dump()
+    assert "start_date" not in dump and "end_date" not in dump


### PR DESCRIPTION
## Summary
- compute human-readable project durations and drop exact start/end dates
- update project schema to store only duration
- test project extraction to ensure dates removed and durations computed

## Testing
- `cd cvbuilder && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5205688c832faf836936089a9c1d