### PR TITLE
Add pipelines for all resume sections

### DIFF
--- a/cvbuilder/main.py
+++ b/cvbuilder/main.py
@@ -1,35 +1,28 @@
-from src.notion.notion import Notion
-from src.cv_agent.selector import CVSelector
+from src.pipeline import (
+    personal as personal_pipeline,
+    projects as project_pipeline,
+    skills as skills_pipeline,
+    experience as experience_pipeline,
+    education as education_pipeline,
+    certificates as certificates_pipeline,
+)
 from src.latex import compile_latex, render_resume, save_tex
-from src.utils.commons import load_json
 
-import os
 from dotenv import load_dotenv
 
 # Load env vars
 load_dotenv(".env")
 
-# Constants
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
-LATEX_DIR = os.path.join(BASE_DIR, 'latex_data')
-
 if __name__ == "__main__":
-    # Step 1: Sync data from Notion
-    notion = Notion()
-    notion.sync_all()
+    # Build each resume section via its dedicated pipeline
+    contact = personal_pipeline.run()
+    projects = project_pipeline.run()
+    skills = skills_pipeline.run()
+    experience = experience_pipeline.run()
+    education = education_pipeline.run()
+    certificates_pipeline.run()
 
-    # Step 2: Run AI agent to select best content
-    selector = CVSelector(mode=os.getenv("MODE", "local"), model=os.getenv("MODEL", "deepseek-coder:6.7b"))
-    selector.run_all()
-
-    # Step 3: Load filtered JSON data for LaTeX rendering
-    contact = load_json(os.path.join(LATEX_DIR, 'contact.json'))
-    skills = load_json(os.path.join(LATEX_DIR, 'skills.json'))
-    projects = load_json(os.path.join(LATEX_DIR, 'projects.json'))
-    experience = load_json(os.path.join(LATEX_DIR, 'experience.json'))
-    education = load_json(os.path.join(LATEX_DIR, 'education.json'))
-
-    # Step 4: Render + Save LaTeX + Compile
+    # Render + Save LaTeX + Compile
     tex = render_resume(contact, skills, projects, experience, education)
     save_tex(tex)
     compile_latex()

--- a/cvbuilder/src/pipeline/__init__.py
+++ b/cvbuilder/src/pipeline/__init__.py
@@ -1,0 +1,10 @@
+"""Collection of pipelines for building resume sections."""
+
+__all__ = [
+    "projects",
+    "skills",
+    "personal",
+    "experience",
+    "education",
+    "certificates",
+]

--- a/cvbuilder/src/pipeline/certificates.py
+++ b/cvbuilder/src/pipeline/certificates.py
@@ -1,0 +1,38 @@
+"""Pipeline utilities for building the certificates section."""
+
+import os
+import json
+from src.notion import certificates as notion_certificates
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Fetch certificates data from Notion and store raw JSON."""
+    notion_certificates.run()
+
+
+def select_relevant():
+    """Copy raw certificates data to LaTeX directory."""
+    src_path = os.path.join(DATA_DIR, "certificates.json")
+    dst_path = os.path.join(LATEX_DIR, "certificates.json")
+    os.makedirs(LATEX_DIR, exist_ok=True)
+    data = load_json(src_path)
+    with open(dst_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def render_section():
+    """Load curated certificates JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "certificates.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full certificates pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()

--- a/cvbuilder/src/pipeline/education.py
+++ b/cvbuilder/src/pipeline/education.py
@@ -1,0 +1,38 @@
+"""Pipeline utilities for building the education section."""
+
+import os
+import json
+from src.notion import education as notion_education
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Fetch education data from Notion and store raw JSON."""
+    notion_education.run()
+
+
+def select_relevant():
+    """Copy raw education data to LaTeX directory."""
+    src_path = os.path.join(DATA_DIR, "education.json")
+    dst_path = os.path.join(LATEX_DIR, "education.json")
+    os.makedirs(LATEX_DIR, exist_ok=True)
+    data = load_json(src_path)
+    with open(dst_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def render_section():
+    """Load curated education JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "education.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full education pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()

--- a/cvbuilder/src/pipeline/experience.py
+++ b/cvbuilder/src/pipeline/experience.py
@@ -1,0 +1,38 @@
+"""Pipeline utilities for building the experience section."""
+
+import os
+import json
+from src.notion import experience as notion_experience
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Fetch experience data from Notion and store raw JSON."""
+    notion_experience.run()
+
+
+def select_relevant():
+    """Copy raw experience data to LaTeX directory."""
+    src_path = os.path.join(DATA_DIR, "experience.json")
+    dst_path = os.path.join(LATEX_DIR, "experience.json")
+    os.makedirs(LATEX_DIR, exist_ok=True)
+    data = load_json(src_path)
+    with open(dst_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def render_section():
+    """Load curated experience JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "experience.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full experience pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()

--- a/cvbuilder/src/pipeline/personal.py
+++ b/cvbuilder/src/pipeline/personal.py
@@ -1,0 +1,55 @@
+"""Pipeline utilities for building the contact section."""
+
+import os
+import json
+from src.notion import personal as notion_personal
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Fetch personal information from Notion and store raw JSON."""
+    notion_personal.run()
+
+
+def select_relevant():
+    """Convert raw personal info into LaTeX-ready contact data."""
+    src_path = os.path.join(DATA_DIR, "personal_info.json")
+    dst_path = os.path.join(LATEX_DIR, "contact.json")
+    os.makedirs(LATEX_DIR, exist_ok=True)
+    data = load_json(src_path)
+
+    contact = {}
+    for item in data:
+        key = item.get("key", "").strip().lower().replace(" ", "_")
+        value = item.get("value", "")
+        if not key:
+            continue
+        if key in contact:
+            if isinstance(contact[key], list):
+                contact[key].append(value)
+            else:
+                contact[key] = [contact[key], value]
+        else:
+            contact[key] = value
+    if isinstance(contact.get("github"), list):
+        contact["githubs"] = contact.pop("github")
+
+    with open(dst_path, "w", encoding="utf-8") as f:
+        json.dump(contact, f, indent=2, ensure_ascii=False)
+
+
+def render_section():
+    """Load curated contact JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "contact.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full contact pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()

--- a/cvbuilder/src/pipeline/projects.py
+++ b/cvbuilder/src/pipeline/projects.py
@@ -1,0 +1,36 @@
+"""Pipeline utilities for building the projects section."""
+
+import os
+from src.notion import projects as notion_projects
+from src.cv_agent.selector import CVSelector
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Fetch project data from Notion and store raw JSON."""
+    notion_projects.run()
+
+
+def select_relevant():
+    """Run AI selector to curate projects for LaTeX output."""
+    selector = CVSelector(
+        mode=os.getenv("MODE", "local"),
+        model=os.getenv("MODEL", "deepseek-coder:6.7b"),
+    )
+    selector.select_projects()
+
+
+def render_section():
+    """Load curated projects JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "projects.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full projects pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()

--- a/cvbuilder/src/pipeline/skills.py
+++ b/cvbuilder/src/pipeline/skills.py
@@ -1,0 +1,36 @@
+"""Pipeline utilities for building the skills section."""
+
+import os
+from src.notion import skills as notion_skills
+from src.cv_agent.selector import CVSelector
+from src.utils.commons import load_json
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
+
+
+def fetch_raw():
+    """Generate raw skills from projects data."""
+    notion_skills.generate_skills_from_projects()
+
+
+def select_relevant():
+    """Run AI selector to curate skills for LaTeX output."""
+    selector = CVSelector(
+        mode=os.getenv("MODE", "local"),
+        model=os.getenv("MODEL", "deepseek-coder:6.7b"),
+    )
+    selector.select_skills()
+
+
+def render_section():
+    """Load curated skills JSON ready for LaTeX rendering."""
+    path = os.path.join(LATEX_DIR, "skills.json")
+    return load_json(path)
+
+
+def run():
+    """Execute the full skills pipeline and return LaTeX data."""
+    fetch_raw()
+    select_relevant()
+    return render_section()


### PR DESCRIPTION
## Summary
- add pipeline modules for contact, skills, experience, education, and certificates
- update main entry point to run all pipelines before rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7453f1d4832fa33101c4a660b184