### PR TITLE
Use top-level notion clients in pipelines

### DIFF
--- a/cvbuilder/src/pipeline/certificates.py
+++ b/cvbuilder/src/pipeline/certificates.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from src.notion import certificates as notion_certificates
+from notion import Certificates
 from src.utils.commons import load_json
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -12,7 +12,8 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Fetch certificates data from Notion and store raw JSON."""
-    notion_certificates.run()
+    client = Certificates()
+    client.sync()
 
 
 def select_relevant():

--- a/cvbuilder/src/pipeline/education.py
+++ b/cvbuilder/src/pipeline/education.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from src.notion import education as notion_education
+from notion import Education
 from src.utils.commons import load_json
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -12,7 +12,8 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Fetch education data from Notion and store raw JSON."""
-    notion_education.run()
+    client = Education()
+    client.sync()
 
 
 def select_relevant():

--- a/cvbuilder/src/pipeline/experience.py
+++ b/cvbuilder/src/pipeline/experience.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from src.notion import experience as notion_experience
+from notion import Experience
 from src.utils.commons import load_json
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -12,7 +12,8 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Fetch experience data from Notion and store raw JSON."""
-    notion_experience.run()
+    client = Experience()
+    client.sync()
 
 
 def select_relevant():

--- a/cvbuilder/src/pipeline/personal.py
+++ b/cvbuilder/src/pipeline/personal.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from src.notion import personal as notion_personal
+from notion import PersonalInfo
 from src.utils.commons import load_json
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
@@ -12,7 +12,8 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Fetch personal information from Notion and store raw JSON."""
-    notion_personal.run()
+    client = PersonalInfo()
+    client.sync()
 
 
 def select_relevant():

--- a/cvbuilder/src/pipeline/projects.py
+++ b/cvbuilder/src/pipeline/projects.py
@@ -1,7 +1,7 @@
 """Pipeline utilities for building the projects section."""
 
 import os
-from src.notion import projects as notion_projects
+from notion import Projects
 from src.cv_agent.selector import CVSelector
 from src.utils.commons import load_json
 
@@ -11,7 +11,8 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Fetch project data from Notion and store raw JSON."""
-    notion_projects.run()
+    client = Projects()
+    client.sync()
 
 
 def select_relevant():

--- a/cvbuilder/src/pipeline/skills.py
+++ b/cvbuilder/src/pipeline/skills.py
@@ -1,7 +1,7 @@
 """Pipeline utilities for building the skills section."""
 
 import os
-from src.notion import skills as notion_skills
+from notion.skills import generate_skills_from_projects
 from src.cv_agent.selector import CVSelector
 from src.utils.commons import load_json
 
@@ -11,7 +11,7 @@ LATEX_DIR = os.path.join(BASE_DIR, "latex_data")
 
 def fetch_raw():
     """Generate raw skills from projects data."""
-    notion_skills.generate_skills_from_projects()
+    generate_skills_from_projects()
 
 
 def select_relevant():


### PR DESCRIPTION
## Summary
- Import Notion clients directly from the top-level `notion` package across pipeline modules
- Instantiate and sync clients instead of calling deprecated `run()` helpers
- Generate skills using `notion.skills.generate_skills_from_projects`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f7f4a1eb4832fb5a9b544964a5237