### PR TITLE
Add duration calculation for Notion project entries

### DIFF
--- a/cvbuilder/notion/projects.py
+++ b/cvbuilder/notion/projects.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import os
-from typing import List
+from datetime import datetime
+from typing import List, Optional
 
 from .client import NotionClient
 from src.schemas.notion import Project
@@ -14,6 +15,28 @@ logger = get_logger("notion-projects")
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 DATA_PATH = os.path.join(BASE_DIR, "data", "projects.json")
+
+
+def _compute_duration(start: Optional[str], end: Optional[str]) -> str:
+    """Return human readable duration between two ISO date strings."""
+    if not start:
+        return ""
+    try:
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end) if end else datetime.now()
+    except (TypeError, ValueError):
+        return ""
+
+    months = (end_dt.year - start_dt.year) * 12 + (end_dt.month - start_dt.month)
+    if months <= 0:
+        months = 1
+    years, months = divmod(months, 12)
+    parts = []
+    if years:
+        parts.append(f"{years} yr")
+    if months:
+        parts.append(f"{months} mo")
+    return " ".join(parts)
 
 
 class Projects(NotionClient):
@@ -39,9 +62,10 @@ class Projects(NotionClient):
             tech_stack = [t["name"] for t in properties.get("Tech Stack", {}).get("multi_select", [])]
             description = properties.get("Description", {}).get("rich_text", [{}])[0].get("text", {}).get("content", "No Description")
             notes = properties.get("Detailed Notes", {}).get("rich_text", [{}])[0].get("text", {}).get("content", "No Notes")
-            start_date = properties.get("Start Date", {}).get("date", {}).get("start", "No Start Date")
+            start_date = properties.get("Start Date", {}).get("date", {}).get("start")
             end_date_prop = properties.get("End Date")
-            end_date = end_date_prop["date"]["start"] if end_date_prop and end_date_prop.get("date") else "No End Date"
+            end_date = end_date_prop["date"]["start"] if end_date_prop and end_date_prop.get("date") else None
+            duration = _compute_duration(start_date, end_date)
             role = properties.get("Role", {}).get("select", {}).get("name", "No Role")
             tags = [t["name"] for t in properties.get("Tags", {}).get("multi_select", [])]
             project_entry = Project(
@@ -51,8 +75,7 @@ class Projects(NotionClient):
                 tech_stack=tech_stack,
                 description=description,
                 notes=notes,
-                start_date=start_date,
-                end_date=end_date,
+                duration=duration,
                 role=role,
                 tags=tags,
             )


### PR DESCRIPTION
## Summary
- compute duration between start and end dates for Notion projects
- remove unsupported start/end fields when creating Project models
- pass only schema-defined fields to Project, including duration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7f4b9c90832f96cd3923200cd0c9