### PR TITLE
Gracefully handle missing email in LaTeX resume generation

### DIFF
--- a/cvbuilder/src/latex.py
+++ b/cvbuilder/src/latex.py
@@ -60,16 +60,36 @@ def render_resume(contact, skills, projects, experience, education):
             tex = f.read()
 
         # Contact info block
-        tex += f"""\\namesection{{{escape_latex(contact['name'])}}}{{%
-{escape_latex(contact['phone'])} \\\\
-\\href{{mailto:{escape_latex(contact['email'])}}}{{{escape_latex(contact['email'])}}} \\\\
-LinkedIn: \\href{{{escape_latex(contact['linkedin'])}}}{{{escape_latex(contact['linkedin'].replace('https://',''))}}} \\\\
-"""
+        tex += f"\\namesection{{{escape_latex(contact.get('name', ''))}}}{{%\n"
+
+        contact_lines = []
+
+        if contact.get("phone"):
+            contact_lines.append(escape_latex(contact["phone"]))
+
+        if contact.get("email"):
+            contact_lines.append(
+                f"\\href{{mailto:{escape_latex(contact['email'])}}}{{{escape_latex(contact['email'])}}}"
+            )
+
+        if contact.get("linkedin"):
+            contact_lines.append(
+                f"LinkedIn: \\href{{{escape_latex(contact['linkedin'])}}}{{{escape_latex(contact['linkedin'].replace('https://',''))}}}"
+            )
+
         if "githubs" in contact:
             for gh in contact["githubs"]:
-                tex += f'{escape_latex(gh["label"])} GitHub: \\href{{{escape_latex(gh["url"])}}}{{{escape_latex(gh["url"].replace("https://", ""))}}} \\\\\n'
-        elif "github" in contact:
-            tex += f'GitHub: \\href{{{escape_latex(contact["github"])}}}{{{escape_latex(contact["github"].replace("https://", ""))}}}\n'
+                contact_lines.append(
+                    f"{escape_latex(gh['label'])} GitHub: \\href{{{escape_latex(gh['url'])}}}{{{escape_latex(gh['url'].replace('https://', ''))}}}"
+                )
+        elif contact.get("github"):
+            contact_lines.append(
+                f"GitHub: \\href{{{escape_latex(contact['github'])}}}{{{escape_latex(contact['github'].replace('https://', ''))}}}"
+            )
+
+        if contact_lines:
+            tex += " \\\n".join(contact_lines) + " \\\n"
+
         tex += "}\n"
 
         # Add your sections

--- a/cvbuilder/tests/test_render_resume_contact.py
+++ b/cvbuilder/tests/test_render_resume_contact.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.latex import render_resume
+
+def test_render_resume_missing_email():
+    contact = {"name": "John Doe", "phone": "+1 234 567 890"}
+    tex = render_resume(contact, [], [], [], [])
+    assert "John Doe" in tex
+    assert "mailto" not in tex
+


### PR DESCRIPTION
## Summary
- Build contact block dynamically in `render_resume` to handle missing email, phone, or social links without crashing.
- Add regression test ensuring resumes render when email is absent.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f82a228f4832f96d4f2302e64c4dc