### PR TITLE
Remove redundant itemize in skills template

### DIFF
--- a/cvbuilder/templates/skills.tex.j2
+++ b/cvbuilder/templates/skills.tex.j2
@@ -1,7 +1,5 @@
 \begin{sectionheader_nobullet}{Skills}
-\begin{itemize}[leftmargin=0em,label={},itemsep=0pt,topsep=0pt]
 {% for cat in skills %}
   \item \textbf{ {{ cat.category | escape_latex }} }: {{ cat["items"] | map('escape_latex') | join(", ") }}
 {% endfor %}
-\end{itemize}
 \end{sectionheader_nobullet}


### PR DESCRIPTION
## Summary
- Simplify the skills template by removing the nested itemize environment so skill items render directly within the section header.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f84df546c832fa953b0c05e8113dc