### PR TITLE
Handle empty education section

### DIFF
--- a/cvbuilder/templates/education.tex.j2
+++ b/cvbuilder/templates/education.tex.j2
@@ -1,3 +1,4 @@
+{% if education %}
 \begin{sectionheader}{Education}
 {% for school in education if school.school %}
   \item \textbf{ {{ school.school | escape_latex }} } \hfill {\emph{ {{ school.dates | escape_latex }} }} \\
@@ -5,3 +6,8 @@
         {\footnotesize {{ school.details | escape_latex }}}
 {% endfor %}
 \end{sectionheader}
+{% else %}
+\begin{sectionheader}{Education}
+  \item No education information provided
+\end{sectionheader}
+{% endif %}


### PR DESCRIPTION
## Summary
- render education section only when entries exist, otherwise show placeholder text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f84ea655c832fbff62ce7ffa7bc53