### PR TITLE
Add LaTeX-ready transformations for education and experience

### DIFF
--- a/cvbuilder/notion/education.py
+++ b/cvbuilder/notion/education.py
@@ -64,6 +64,48 @@ class EducationClient(NotionClient):
             education.append(edu_entry)
         return education
 
+    def transform_for_latex(self, data: List[EducationModel | dict]) -> List[dict]:
+        """Transform education models into LaTeX-friendly dictionaries."""
+        transformed = []
+        for entry in data:
+            edu = EducationModel(**entry) if isinstance(entry, dict) else entry
+
+            degree_parts = []
+            if edu.level:
+                degree_parts.append(edu.level)
+            if edu.field:
+                degree_parts.append(f"in {edu.field}")
+            degree = " ".join(degree_parts).strip()
+
+            details_parts = []
+            if edu.specialization:
+                details_parts.append(f"Specialization in {edu.specialization}")
+            if edu.duration_years:
+                years = (
+                    int(edu.duration_years)
+                    if isinstance(edu.duration_years, float)
+                    and edu.duration_years.is_integer()
+                    else edu.duration_years
+                )
+                details_parts.append(f"[{years} years]")
+            details = " ".join(details_parts).strip()
+
+            dates = ""
+            if edu.start_date or edu.end_date:
+                start = edu.start_date or ""
+                end = edu.end_date or "Present"
+                dates = f"{start} – {end}".strip()
+
+            transformed.append(
+                {
+                    "school": edu.university or "",
+                    "degree": degree,
+                    "details": details,
+                    "dates": dates,
+                }
+            )
+        return transformed
+
     def save(self, data: List[EducationModel]) -> None:
         os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
         with open(DATA_PATH, "w", encoding="utf-8") as f:

--- a/cvbuilder/notion/experience.py
+++ b/cvbuilder/notion/experience.py
@@ -53,6 +53,36 @@ class ExperienceClient(NotionClient):
             experiences.append(exp_entry)
         return experiences
 
+    def transform_for_latex(self, data: List[ExperienceModel | dict]) -> List[dict]:
+        """Transform experience models into LaTeX-friendly dictionaries."""
+        transformed = []
+        for entry in data:
+            exp = ExperienceModel(**entry) if isinstance(entry, dict) else entry
+
+            dates = ""
+            if exp.start_date or exp.end_date:
+                start = exp.start_date or ""
+                end = exp.end_date or "Present"
+                dates = f"{start} – {end}".strip()
+
+            desc_parts = []
+            if exp.employment_type:
+                desc_parts.append(exp.employment_type)
+            if exp.duration:
+                desc_parts.append(exp.duration)
+            description = " – ".join(desc_parts).strip()
+
+            transformed.append(
+                {
+                    "company": exp.company or "",
+                    "position": exp.role or "",
+                    "description": description,
+                    "dates": dates,
+                }
+            )
+
+        return transformed
+
     def save(self, data: List[ExperienceModel]) -> None:
         os.makedirs(os.path.dirname(DATA_PATH), exist_ok=True)
         with open(DATA_PATH, "w", encoding="utf-8") as f:

--- a/cvbuilder/src/pipeline/education.py
+++ b/cvbuilder/src/pipeline/education.py
@@ -17,13 +17,15 @@ def fetch_raw():
 
 
 def select_relevant():
-    """Copy raw education data to LaTeX directory."""
+    """Transform raw education data for LaTeX and save."""
     src_path = os.path.join(DATA_DIR, "education.json")
     dst_path = os.path.join(LATEX_DIR, "education.json")
     os.makedirs(LATEX_DIR, exist_ok=True)
-    data = load_json(src_path)
+    raw = load_json(src_path)
+    client = Education()
+    transformed = client.transform_for_latex(raw)
     with open(dst_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+        json.dump(transformed, f, indent=2, ensure_ascii=False)
 
 
 def render_section():

--- a/cvbuilder/src/pipeline/experience.py
+++ b/cvbuilder/src/pipeline/experience.py
@@ -17,13 +17,15 @@ def fetch_raw():
 
 
 def select_relevant():
-    """Copy raw experience data to LaTeX directory."""
+    """Transform raw experience data for LaTeX and save."""
     src_path = os.path.join(DATA_DIR, "experience.json")
     dst_path = os.path.join(LATEX_DIR, "experience.json")
     os.makedirs(LATEX_DIR, exist_ok=True)
-    data = load_json(src_path)
+    raw = load_json(src_path)
+    client = Experience()
+    transformed = client.transform_for_latex(raw)
     with open(dst_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+        json.dump(transformed, f, indent=2, ensure_ascii=False)
 
 
 def render_section():

--- a/cvbuilder/tests/test_transformations.py
+++ b/cvbuilder/tests/test_transformations.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from notion.education import EducationClient
+from notion.experience import ExperienceClient
+
+
+def test_education_transform():
+    client = EducationClient()
+    data = [
+        {
+            "level": "Bachelor",
+            "university": "MIT",
+            "field": "Computer Science",
+            "specialization": "AI",
+            "start_date": "2018",
+            "end_date": "2022",
+            "duration_years": 4,
+        }
+    ]
+    transformed = client.transform_for_latex(data)
+    assert transformed == [
+        {
+            "school": "MIT",
+            "degree": "Bachelor in Computer Science",
+            "details": "Specialization in AI [4 years]",
+            "dates": "2018 – 2022",
+        }
+    ]
+
+
+def test_experience_transform():
+    client = ExperienceClient()
+    data = [
+        {
+            "role": "Engineer",
+            "company": "Acme",
+            "start_date": "2020",
+            "end_date": None,
+            "employment_type": "Full-time",
+            "duration": "1 yr",
+        }
+    ]
+    transformed = client.transform_for_latex(data)
+    assert transformed == [
+        {
+            "company": "Acme",
+            "position": "Engineer",
+            "description": "Full-time – 1 yr",
+            "dates": "2020 – Present",
+        }
+    ]
+


### PR DESCRIPTION
## Summary
- transform Notion education entries into `school/degree/details/dates`
- transform Notion experience entries into `company/position/description/dates`
- pipe transformed data into `latex_data` and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f84fab240832f846f1df04caded2e