### PR TITLE
Handle LaTeX compilation errors

### DIFF
--- a/cvbuilder/main.py
+++ b/cvbuilder/main.py
@@ -7,11 +7,17 @@ from src.pipeline import (
     certificates as certificates_pipeline,
 )
 from src.latex import compile_latex, render_resume, save_tex
+from src.utils.logger import get_logger
+
+import subprocess
+import sys
 
 from dotenv import load_dotenv
 
 # Load env vars
 load_dotenv(".env")
+
+logger = get_logger("main")
 
 if __name__ == "__main__":
     # Build each resume section via its dedicated pipeline
@@ -25,4 +31,11 @@ if __name__ == "__main__":
     # Render + Save LaTeX + Compile
     tex = render_resume(contact, skills, projects, experience, education)
     save_tex(tex)
-    compile_latex()
+    try:
+        compile_latex()
+    except subprocess.CalledProcessError as e:
+        logger.error("LaTeX compilation failed. See logs above for details.")
+        sys.exit(e.returncode or 1)
+    except FileNotFoundError:
+        logger.error("pdflatex not found. Please ensure LaTeX is installed and in your PATH.")
+        sys.exit(1)

--- a/cvbuilder/src/latex.py
+++ b/cvbuilder/src/latex.py
@@ -27,8 +27,10 @@ def compile_latex(latex_file="main.tex", working_dir=TEMPLATE_DIR, output_dir=OU
         logger.info(f"Compilation successful! PDF is in {output_dir}")
     except subprocess.CalledProcessError as e:
         logger.exception("Error in compilation")
+        raise
     except FileNotFoundError:
         logger.exception("Error: pdflatex not found. Please ensure LaTeX is installed and in your PATH.")
+        raise
 
 def escape_latex(s):
     if not isinstance(s, str):


### PR DESCRIPTION
## Summary
- Propagate LaTeX compilation failures by re-raising errors in `compile_latex`
- Add error handling in `main.py` to exit with informative messages when LaTeX or pdflatex is missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f85522ffc832fb88ace8f3801b7a2