### PR TITLE
Refactor project selection with per-project guardrails

### DIFF
--- a/cvbuilder/src/cv_agent/agent.py
+++ b/cvbuilder/src/cv_agent/agent.py
@@ -18,9 +18,19 @@ logger.setLevel(logging.DEBUG)
 
 
 class CVAgent:
-    def __init__(self, mode: Literal["openai", "local"] = "openai", model: str = "gpt-4"):
+    def __init__(
+        self,
+        mode: Literal["openai", "local"] = "openai",
+        model: str = "gpt-4",
+        *,
+        temperature: float = 0.2,
+        top_p: float = 0.9,
+    ):
+        """Initialize the agent with sensible defaults for deterministic output."""
         self.mode = mode
         self.model = model
+        self.temperature = temperature
+        self.top_p = top_p
         if mode == "openai":
             self.client = OpenAI()
         elif mode == "local":
@@ -71,6 +81,8 @@ class CVAgent:
             params = {
                 "model": self.model,
                 "messages": [{"role": "user", "content": prompt}],
+                "temperature": self.temperature,
+                "top_p": self.top_p,
             }
             if schema is not None:
                 params["response_format"] = {
@@ -90,7 +102,13 @@ class CVAgent:
         self, prompt: str, schema: Optional[Type[BaseModel]] = None
     ) -> str:
         url = f"{self.ollama_host}/api/generate"
-        payload = {"model": self.model, "prompt": prompt, "stream": False}
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
         if schema is not None:
             payload["format"] = schema.model_json_schema()
         else:

--- a/cvbuilder/src/cv_agent/prompts/extract_signals.txt
+++ b/cvbuilder/src/cv_agent/prompts/extract_signals.txt
@@ -1,0 +1,14 @@
+You are extracting hiring signals from a job description.
+Job Description:
+{job_desc}
+
+Return a JSON object with this schema:
+{
+  "keywords": ["core technologies or concepts"],
+  "tools": ["dev tools or platforms"],
+  "cloud": ["cloud providers or services"],
+  "nice_to_have": ["optional skills"],
+  "weights": {"keywords": 1, "tools": 1, "cloud": 1, "nice_to_have": 0.5}
+}
+
+Use lowercase strings. Respond ONLY with valid JSON.

--- a/cvbuilder/src/cv_agent/prompts/rewrite_project.txt
+++ b/cvbuilder/src/cv_agent/prompts/rewrite_project.txt
@@ -1,0 +1,24 @@
+You are writing a resume project entry.
+Job description signals:
+{signals}
+
+Original project data:
+{project}
+
+Allowed terms:
+{allowed_terms}
+
+Rewrite the project for a CV:
+- Only use technology terms present in Allowed terms.
+- Provide a brief "title" and a 1-2 sentence "description".
+- Provide up to 3 bullet "accomplishments".
+- Keep total characters under {max_chars}.
+- Preserve the provided "duration".
+
+Respond ONLY with valid JSON following this schema:
+{
+  "title": "...",
+  "description": "...",
+  "accomplishments": ["..."],
+  "duration": "..."
+}

--- a/cvbuilder/src/cv_agent/selector.py
+++ b/cvbuilder/src/cv_agent/selector.py
@@ -2,9 +2,14 @@
 
 import os
 import json
+import re
+from collections import defaultdict
+from typing import Dict, List
+
 from src.cv_agent.agent import CVAgent
 from src.utils.logger import get_logger
 from src.schemas.latex_data import ProjectsSchema, SkillsSchema
+from src.schemas.selector import HiringSignals, RewrittenProject
 from src.cv_agent.validator import ask_and_validate_json
 
 logger = get_logger("cv-selector")
@@ -51,28 +56,145 @@ class CVSelector:
         os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
         with open(LOG_FILE, "a", encoding="utf-8") as log:
             log.write(f"\n--- {context} ---\nPROMPT:\n{prompt}\n\nRESPONSE:\n{response}\n\n")
+    # ------------------------ Project Selection ---------------------
+    def _extract_signals(self, job_desc: str) -> Dict:
+        """Stage 1: Extract hiring signals from job description."""
+        prompt = self._load_prompt("extract_signals.txt", job_desc=job_desc)
+        return ask_and_validate_json(
+            self.agent,
+            prompt,
+            "Signal Extraction",
+            schema=HiringSignals,
+            retries=1,
+            log_callback=self._save_debug_log,
+        )
+
+    def _score_projects(
+        self, signals: Dict, projects: List[Dict], top_n: int = 6
+    ) -> List[Dict]:
+        """Stage 2: Score projects lexically against hiring signals."""
+        weights = signals.get("weights", {})
+
+        def score(p: Dict) -> float:
+            text = " ".join(
+                [
+                    p.get("name", ""),
+                    p.get("description", ""),
+                    p.get("notes", ""),
+                    " ".join(p.get("tech_stack", [])),
+                    " ".join(p.get("tags", [])),
+                ]
+            ).lower()
+            total = 0.0
+            for term in signals.get("keywords", []):
+                if term.lower() in text:
+                    total += weights.get("keywords", 1)
+            for term in signals.get("tools", []):
+                if term.lower() in text:
+                    total += weights.get("tools", 1)
+            for term in signals.get("cloud", []):
+                if term.lower() in text:
+                    total += weights.get("cloud", 1)
+            for term in signals.get("nice_to_have", []):
+                if term.lower() in text:
+                    total += weights.get("nice_to_have", 1)
+            return total
+
+        scored = sorted(projects, key=score, reverse=True)
+        return scored[:top_n]
+
+    def _extract_allowed_terms(self, project: Dict) -> List[str]:
+        """Derive allowed technology terms from project data."""
+        allowed = set()
+        for field in ("tech_stack", "tags"):
+            for t in project.get(field, []):
+                allowed.add(t.lower())
+        text = f"{project.get('description', '')} {project.get('notes', '')}"
+        tokens = re.findall(r"\b[A-Za-z][A-Za-z0-9\+\#\.]*\b", text)
+        for tok in tokens:
+            if any(c.isupper() or c.isdigit() for c in tok):
+                allowed.add(tok.lower())
+        return sorted(allowed)
+
+    def _strip_disallowed(self, text: str, allowed: set) -> str:
+        """Remove technology terms not present in allowed set."""
+
+        def repl(match: re.Match) -> str:
+            word = match.group(0)
+            if any(c.isupper() or c.isdigit() for c in word) and word.lower() not in allowed:
+                return ""
+            return word
+
+        return re.sub(r"\b[A-Za-z][A-Za-z0-9\+\#\.]*\b", repl, text)
+
+    def _enforce_total_budget(self, items: List[Dict], max_chars: int) -> None:
+        """Trim accomplishments to satisfy global character budget."""
+
+        def current_len() -> int:
+            return sum(len(i["description"]) + len(i["details"]) for i in items)
+
+        while current_len() > max_chars:
+            longest = max(items, key=lambda x: len(x["details"].split("\n")))
+            details = longest["details"].split("\n")
+            if not details:
+                break
+            details.pop()
+            longest["details"] = "\n".join(details).strip()
 
     def select_projects(self):
         job_desc = self._load_job_description()
         projects = self._load_data("projects.json")
-        max_chars = self.config["max_characters"]["projects"]
+        max_total_chars = self.config["max_characters"]["projects"]
 
-        prompt = self._load_prompt(
-            "select_projects.txt",
-            job_desc=job_desc,
-            projects=json.dumps(projects, indent=2),
-            max_chars=max_chars
-        )
+        signals = self._extract_signals(job_desc)
+        top_projects = self._score_projects(signals, projects, top_n=6)
+        max_per_project = max_total_chars // max(len(top_projects), 1)
 
-        parsed = ask_and_validate_json(
-            self.agent,
-            prompt,
-            "Project Selection",
-            schema=ProjectsSchema,
-            retries=1,
-            log_callback=self._save_debug_log,
-        )
-        self._save_latex("projects.json", parsed)
+        rewritten_items: List[Dict] = []
+        for proj in top_projects:
+            allowed_terms = self._extract_allowed_terms(proj)
+            prompt = self._load_prompt(
+                "rewrite_project.txt",
+                signals=json.dumps(signals, indent=2),
+                project=json.dumps(proj, indent=2),
+                allowed_terms=json.dumps(allowed_terms),
+                max_chars=max_per_project,
+            )
+            rewritten = ask_and_validate_json(
+                self.agent,
+                prompt,
+                f"Rewrite Project: {proj.get('name')}",
+                schema=RewrittenProject,
+                retries=1,
+                log_callback=self._save_debug_log,
+            )
+            allowed_set = set(allowed_terms)
+            rewritten["description"] = self._strip_disallowed(
+                rewritten["description"], allowed_set
+            ).strip()
+            rewritten["accomplishments"] = [
+                self._strip_disallowed(a, allowed_set).strip()
+                for a in rewritten["accomplishments"]
+            ]
+            item = {
+                "title": rewritten["title"],
+                "description": rewritten["description"],
+                "details": "\n".join(filter(None, rewritten["accomplishments"])),
+                "duration": rewritten["duration"],
+                "category": proj.get("category", "General"),
+            }
+            rewritten_items.append(item)
+
+        self._enforce_total_budget(rewritten_items, max_total_chars)
+
+        grouped: Dict[str, List[Dict]] = defaultdict(list)
+        for item in rewritten_items:
+            category = item.pop("category")
+            grouped[category].append(item)
+        final_data = [{"category": cat, "items": items} for cat, items in grouped.items()]
+
+        validated = ProjectsSchema.model_validate(final_data).model_dump(mode="python")
+        self._save_latex("projects.json", validated)
         logger.info("Selected projects saved to LaTeX folder.")
 
     def select_skills(self):

--- a/cvbuilder/src/schemas/selector.py
+++ b/cvbuilder/src/schemas/selector.py
@@ -1,0 +1,19 @@
+from typing import Dict, List
+from pydantic import BaseModel
+
+
+class HiringSignals(BaseModel):
+    """Structured signals extracted from a job description."""
+    keywords: List[str]
+    tools: List[str]
+    cloud: List[str]
+    nice_to_have: List[str]
+    weights: Dict[str, float]
+
+
+class RewrittenProject(BaseModel):
+    """Single rewritten project for the resume."""
+    title: str
+    description: str
+    accomplishments: List[str]
+    duration: str


### PR DESCRIPTION
## Summary
- Refactor project selection into multi-stage pipeline: extract job signals, lexically score projects, and rewrite selected entries individually with AllowedTerms and character budgets
- Add hiring signal and rewritten project schemas along with prompts for signal extraction and project rewriting
- Support deterministic LLM usage by allowing temperature and top_p control in CVAgent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8b1c8f98832fb89a27b20e743242