### PR TITLE
feat: limit number of selected projects

### DIFF
--- a/cvbuilder/src/cv_agent/config.json
+++ b/cvbuilder/src/cv_agent/config.json
@@ -3,5 +3,6 @@
     "projects": 1800,
     "skills": 500
   },
+  "max_projects": 6,
   "job_description_path": "job_descriptions/job.txt"
 }

--- a/cvbuilder/src/cv_agent/selector.py
+++ b/cvbuilder/src/cv_agent/selector.py
@@ -147,7 +147,8 @@ class CVSelector:
         max_total_chars = self.config["max_characters"]["projects"]
 
         signals = self._extract_signals(job_desc)
-        top_projects = self._score_projects(signals, projects, top_n=6)
+        max_projects = self.config.get("max_projects", 6)
+        top_projects = self._score_projects(signals, projects, top_n=max_projects)
         max_per_project = max_total_chars // max(len(top_projects), 1)
 
         rewritten_items: List[Dict] = []


### PR DESCRIPTION
## Summary
- add `max_projects` option to config
- limit project selection by `max_projects`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9345b25c832fb4586b7ca00cea81